### PR TITLE
Update version numbers to avoid warnings

### DIFF
--- a/.github/workflows/workflow_testing.yml
+++ b/.github/workflows/workflow_testing.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     # You can test your matrix by printing the current Python version


### PR DESCRIPTION
Old versions of the actions refer to a node (16) that is being outphased. Instead the newer versions refer to node 20 (which is not).