### PR TITLE
Ensure real number (instead of complex due to small errors)

### DIFF
--- a/deltares_wave_toolbox/cores/core_spectral.py
+++ b/deltares_wave_toolbox/cores/core_spectral.py
@@ -594,7 +594,7 @@ def compute_spectrum_freq_series(
 
     # --- Transform to frequency domain
     df = f[1] - f[0]
-    sFine = 2 * xFreq * np.conj(xFreq) / (df * Ntime * Ntime)
+    sFine = np.real(2 * xFreq * np.conj(xFreq) / (df * Ntime * Ntime))
 
     # --- Perform averaging
     [f_coarse, sVarDens_coarse] = frequency_averaging(f, sFine, dfDesired)


### PR DESCRIPTION
With real (messy ) WHM signals, the sVarDens sometimes becomes complex. Small adjustment to force real numbers (as they should be)