### PR TITLE
Change behaviour of get_spectrum()

### DIFF
--- a/deltares_wave_toolbox/series.py
+++ b/deltares_wave_toolbox/series.py
@@ -409,6 +409,8 @@ class Series(WaveHeights):
         noverlap: int = 0,
         nfft: int = 0,
         windows_type: str = "hann",
+        dfDesired: float = 0.01,
+        use_dfDesired: bool = True,
     ) -> spectrum.Spectrum:
         """create spectrum
 
@@ -429,6 +431,10 @@ class Series(WaveHeights):
             Spectrum in spectrum object
 
         """
+
+        if use_dfDesired:
+            nperseg = np.round((1 / self.dt) / dfDesired).astype(int)
+
         [f, S] = core_spectral.compute_spectrum_welch_wrapper(
             self.xTime,
             dt=self.dt,


### PR DESCRIPTION
Make use of dfDesired in get_spectrum(), same default value as get_spectrum_raw(). Old defaults led to a too coarse spectrum for typical 40 Hz measurements